### PR TITLE
astarte_device: add child_spec function

### DIFF
--- a/lib/astarte_device.ex
+++ b/lib/astarte_device.ex
@@ -111,6 +111,17 @@ defmodule Astarte.Device do
           | {:ignore_ssl_errors, boolean()}
 
   @doc """
+  Returns a specification to start this module under a supervisor.
+  See `Supervisor` in Elixir v1.6+.
+  """
+  def child_spec(arg) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, [arg]}
+    }
+  end
+
+  @doc """
   Start an `Astarte.Device`.
 
   ## Device Options


### PR DESCRIPTION
Allow an Astarte Device to be easily put under a Supervision tree

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>