### PR TITLE
Default max certificate chain length to 10

### DIFF
--- a/lib/astarte_device/tortoise_connection.ex
+++ b/lib/astarte_device/tortoise_connection.ex
@@ -49,6 +49,7 @@ defmodule Astarte.Device.TortoiseConnection do
         cacertfile: :certifi.cacertfile(),
         key: {:RSAPrivateKey, der_private_key},
         cert: der_certificate,
+        depth: 10,
         verify: verify
       ]
 


### PR DESCRIPTION
The erlang default of 1 is too strict. Increase the default value to 10
to make it coincident to OpenSSL default.
Fix #11 