### PR TITLE
Pass customize_hostname_check to SSL options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- Make the HTTP client follow redirects when interacting with Pairing API
+
+### Changed
+- Increase the max certificate chain length to 10.
+
+### Fixed
+- Use a custom check for the hostname so that wildcard SSL certificates are supported.
+
 ## [0.11.1] - 2020-05-18
 
 ## [0.11.0] - 2020-04-13

--- a/lib/astarte_device/tortoise_connection.ex
+++ b/lib/astarte_device/tortoise_connection.ex
@@ -43,6 +43,9 @@ defmodule Astarte.Device.TortoiseConnection do
 
       der_certificate = X509.Certificate.to_der(certificate)
 
+      # This is needed to support wildcard certificates
+      hostname_match_fun = :public_key.pkix_verify_hostname_match_fun(:https)
+
       server_opts = [
         host: broker_host,
         port: broker_port,
@@ -50,7 +53,8 @@ defmodule Astarte.Device.TortoiseConnection do
         key: {:RSAPrivateKey, der_private_key},
         cert: der_certificate,
         depth: 10,
-        verify: verify
+        verify: verify,
+        customize_hostname_check: [match_fun: hostname_match_fun]
       ]
 
       subscriptions = adapt_subscription_topics(initial_subscriptions)


### PR DESCRIPTION
Allow supporting wildcard SSL certificates in the broker

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>