### PR TITLE
Do not require /v1 suffix in pairing_url, add it on our side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Increase the max certificate chain length to 10.
+- Breaking API change: `pairing_url` now MUST NOT include the `/v1` suffix.
 
 ### Fixed
 - Use a custom check for the hostname so that wildcard SSL certificates are supported.

--- a/lib/astarte_api/pairing.ex
+++ b/lib/astarte_api/pairing.ex
@@ -24,7 +24,7 @@ defmodule Astarte.API.Pairing do
   @doc """
   Create a client to access Pairing API.
 
-  `pairing_url` is the URL of the Astarte Pairing API instance the client will connect to, up to (and including) `/v1`. E.g. `https://astarte.api.example.com/pairing/v1` or `http://localhost:4003/v1` for a local installation.
+  `pairing_url` is the base URL of the Astarte Pairing API instance the client will connect to, e.g. `https://astarte.api.example.com/pairing` or `http://localhost:4003` for a local installation.
 
   `realm` is the realm that the API will access
 
@@ -40,7 +40,7 @@ defmodule Astarte.API.Pairing do
         ) ::
           Astarte.API.client()
   def client(pairing_url, realm, opts \\ []) do
-    base_url = Path.join(pairing_url, realm)
+    base_url = Path.join([pairing_url, "v1", realm])
     Astarte.API.client(base_url, opts)
   end
 end

--- a/lib/astarte_device.ex
+++ b/lib/astarte_device.ex
@@ -130,7 +130,7 @@ defmodule Astarte.Device do
   Start an `Astarte.Device`.
 
   ## Device Options
-    * `pairing_url` - URL of the Astarte Pairing API instance the device will connect to, up to (and including) `/v1`. E.g. `https://astarte.api.example.com/pairing/v1` or `http://localhost:4003/v1` for a local installation.
+    * `pairing_url` - base URL of the Astarte Pairing API instance the device will connect to, e.g. `https://astarte.api.example.com/pairing` or `http://localhost:4003` for a local installation.
     * `realm` - Realm which the device belongs to.
     * `device_id` - Device ID of the device. The device ID must be 128-bit long and must be encoded with url-safe base64 without padding. You can generate a random one with `:crypto.strong_rand_bytes(16) |> Base.url_encode64(padding: false)`.
     * `credentials_secret` - The credentials secret obtained when registering the device using Pairing API (to register a device use `Astarte.API.Pairing.Agent.register_device/2` or see https://docs.astarte-platform.org/latest/api/index.html?urls.primaryName=Pairing%20API#/agent/registerDevice).


### PR DESCRIPTION
Adapt to the behaviour to all other device SDK, and hide the detail of the
specific API version that is being used

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>