### PR TITLE
astarte_device: fix binaryblob serialization, use BSON binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [1.0.0-beta.2] - Unreleased
+### Added
+- Add validation when publishing on object aggregate interfaces.
+
+### Fixed
+- Correctly use a BSON binary instead of a string when publishing binaryblob values.
 
 ## [1.0.0-beta.1] - 2020-02-15
 ### Added


### PR DESCRIPTION
binaryblob values were serialized using a string instead of BSON binaries, they
got accepted by DUP regardless and this caused some issues on the triggers side.
While fixing this the code had to be restructured, so some better
validation (including validating object aggregations) was introduced.

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>