### PR TITLE
astarte_device: standardize subscriptions

### DIFF
--- a/lib/astarte_device/impl.ex
+++ b/lib/astarte_device/impl.ex
@@ -392,11 +392,11 @@ defmodule Astarte.Device.Impl do
   end
 
   defp build_subscriptions(client_id, server_interfaces) do
-    control_topic_subscription = "#{client_id}/control/#"
+    control_topic_subscription = "#{client_id}/control/consumer/properties"
 
     interface_topic_subscriptions =
-      Enum.flat_map(server_interfaces, fn %Interface{name: interface_name} ->
-        ["#{client_id}/#{interface_name}", "#{client_id}/#{interface_name}/#"]
+      Enum.map(server_interfaces, fn %Interface{name: interface_name} ->
+        "#{client_id}/#{interface_name}/#"
       end)
 
     [control_topic_subscription | interface_topic_subscriptions]


### PR DESCRIPTION
- Subscribe only to consumer properties control path
- Do not subscribe to the interface root

See https://github.com/astarte-platform/astarte/issues/568

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>