### PR TITLE
Add unregister device feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- Add `unregister_device` to unregister a device, allowing to register it again. 
+
 ## [1.0.0-rc.0] - 2021-05-05
 ### Changed
 - Standardize subscriptions (see

--- a/lib/astarte_api.ex
+++ b/lib/astarte_api.ex
@@ -67,6 +67,13 @@ defmodule Astarte.API do
     |> to_map()
   end
 
+  @spec delete(client :: Astarte.API.client(), url :: String.t()) ::
+          Astarte.API.result()
+  def delete(client, url) do
+    Tesla.delete(client, url)
+    |> to_map()
+  end
+
   @spec to_map(Tesla.Env.result()) :: Astarte.API.result()
   defp to_map({:ok, %Tesla.Env{status: status, headers: headers, body: body}}) do
     {:ok, %{status: status, headers: headers, body: body}}

--- a/lib/astarte_api/pairing/agent.ex
+++ b/lib/astarte_api/pairing/agent.ex
@@ -29,6 +29,12 @@ defmodule Astarte.API.Pairing.Agent do
                 client :: Astarte.API.client(),
                 device_id :: String.t()
               ) :: Astarte.API.result()
+
+    @callback unregister_device(
+                client :: Astarte.API.client(),
+                device_id :: String.t()
+              ) ::
+                Astarte.API.result()
   end
 
   @behaviour Astarte.API.Pairing.Agent.Behaviour
@@ -51,5 +57,26 @@ defmodule Astarte.API.Pairing.Agent do
     body = %{data: %{hw_id: device_id}}
 
     Astarte.API.post(client, url, body)
+  end
+
+  @doc """
+  Unregisters a device.
+   This makes it possible to register it again, even if it already has requested its credentials.
+   All data belonging to the device will be kept as is.
+
+  `client` is a Pairing API client created with `Astarte.API.Pairing.client/3`.
+
+  `device_id` is the device id of a registered Astarte device.`
+
+  ## Return values
+    * `{:ok, result}` if the HTTP request can be performed. `result` will be a map with `status`, `headers` and `body`.
+    * `{:error, reason}` if the HTTP request can't be performed.
+  """
+  @spec unregister_device(client :: Astarte.API.client(), device_id :: String.t()) ::
+          Astarte.API.result()
+  def unregister_device(client, device_id) do
+    url = "/agent/devices/#{device_id}"
+
+    Astarte.API.delete(client, url)
   end
 end


### PR DESCRIPTION
This makes it possible to register the device again, even if it already has requested its credentials.